### PR TITLE
gameslist: Add option for empty dvd drive

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -37,6 +37,7 @@ MainWindow::MainWindow(QWidget *parent) :
         ui->listWidget->addItem(q);
     }
     ui->listWidget->sortItems();
+    ui->listWidget->insertItem(0, new QListWidgetItem(QIcon(":/dvd.svg"), ""));
 }
 
 MainWindow::~MainWindow()

--- a/settingsmanager.cpp
+++ b/settingsmanager.cpp
@@ -61,7 +61,7 @@ const QStringList settingsManager::genArgs(settings *sett,
     args << "-bios" << sett->flash_path;
     args << "-drive" << "file=" + sett->hdd_path + ",index=0,media=disk" +
             (sett->hdd_unlocked ? "" : ",locked");
-    args << "-drive" << "file=" + path + ",index=1,media=cdrom";
+    args << "-drive" << (path != "" ? "file=" + path + "," : "") + "index=1,media=cdrom";
     if (sett->netRulesModel->rowCount() > 0) {
         args << "-net" << "nic,model=nvnet" << "-net";
         QString netRules = "user";


### PR DESCRIPTION
Useful for running your HDD image's default xbe.